### PR TITLE
Add environment variables for API configuration

### DIFF
--- a/amplify.yml
+++ b/amplify.yml
@@ -4,6 +4,9 @@ frontend:
     preBuild:
       commands:
         - npm install
+        - echo "NEXT_PUBLIC_API_BASE_URL=https://pqsnmneda7.execute-api.us-west-2.amazonaws.com/dev" >> .env.local
+        - echo "NEXT_PUBLIC_AWS_REGION=us-west-2" >> .env.local
+        - echo "NEXT_PUBLIC_ENVIRONMENT=dev" >> .env.local
     build:
       commands:
         - npm run build


### PR DESCRIPTION
This PR adds the necessary environment variables to the Amplify build configuration so the frontend can connect to the correct API Gateway URL.

Changes:
- Added NEXT_PUBLIC_API_BASE_URL pointing to the deployed API Gateway
- Added NEXT_PUBLIC_AWS_REGION and NEXT_PUBLIC_ENVIRONMENT
- This should fix the blank page issue by allowing the frontend to connect to the backend API