### PR TITLE
Configure Next.js for static export to fix 404 issue

### DIFF
--- a/amplify.yml
+++ b/amplify.yml
@@ -11,9 +11,18 @@ frontend:
       commands:
         - npm run build
   artifacts:
-    baseDirectory: .next
+    baseDirectory: out
     files:
       - '**/*'
+  customHeaders:
+    - pattern: '**/*'
+      headers:
+        - key: 'Cache-Control'
+          value: 'max-age=0, no-cache, no-store, must-revalidate'
+  redirects:
+    - source: '</^[^.]+$|\.(?!(css|gif|ico|jpg|js|png|txt|svg|woff|ttf|map|json)$)([^.]+$)/>'
+      target: '/index.html'
+      status: '200'
   cache:
     paths:
       - node_modules/**/*

--- a/next.config.js
+++ b/next.config.js
@@ -1,6 +1,11 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true,
+  output: 'export',
+  trailingSlash: true,
+  images: {
+    unoptimized: true
+  }
 }
 
 module.exports = nextConfig


### PR DESCRIPTION
This PR fixes the 404 error by configuring Next.js for static export, which is required for proper deployment on Amplify.

Changes:
- Added 'output: export' to Next.js config
- Updated Amplify to serve from 'out' directory
- Added trailingSlash and unoptimized images config
- This should resolve the blank page and 404 errors