### PR TITLE
Fix API endpoint URL to match frontend component expectations

### DIFF
--- a/amplify.yml
+++ b/amplify.yml
@@ -4,7 +4,7 @@ frontend:
     preBuild:
       commands:
         - npm install
-        - echo "NEXT_PUBLIC_API_BASE_URL=https://pqsnmneda7.execute-api.us-west-2.amazonaws.com/dev" >> .env.local
+        - echo "NEXT_PUBLIC_API_GATEWAY_URL=https://pqsnmneda7.execute-api.us-west-2.amazonaws.com/dev/bugs" >> .env.local
         - echo "NEXT_PUBLIC_AWS_REGION=us-west-2" >> .env.local
         - echo "NEXT_PUBLIC_ENVIRONMENT=dev" >> .env.local
     build:


### PR DESCRIPTION
This PR fixes the 404 API error by correcting the environment variable name and API endpoint URL.

**Issue:**
- Dashboard loads but shows 'API Error: 404'
- Frontend components expect 'NEXT_PUBLIC_API_GATEWAY_URL' but we were setting 'NEXT_PUBLIC_API_BASE_URL'
- API endpoint was missing '/bugs' path

**Fix:**
- Changed environment variable to 'NEXT_PUBLIC_API_GATEWAY_URL'
- Updated API endpoint URL to include '/bugs' path
- Now correctly points to: https://pqsnmneda7.execute-api.us-west-2.amazonaws.com/dev/bugs

This should resolve the 404 error and allow the dashboard to fetch and display bug data.