### PR TITLE
Fix Total Bugs field name to match API response

### DIFF
--- a/src/components/Dashboard/GrafanaDashboard.tsx
+++ b/src/components/Dashboard/GrafanaDashboard.tsx
@@ -38,7 +38,7 @@ const ChartCard = styled(Card)`
 `;
 
 interface BugData {
-  total_bugs: number;
+  total: number;
   by_priority: Record<string, number>;
   by_state: Record<string, number>;
   by_source: Record<string, number>;
@@ -220,7 +220,7 @@ const GrafanaDashboard: React.FC<GrafanaDashboardProps> = ({
           <MetricCard>
             <Statistic
               title="Total Bugs"
-              value={bugData?.total_bugs || 0}
+              value={bugData?.total || 0}
               valueStyle={{ color: '#1890ff' }}
             />
           </MetricCard>


### PR DESCRIPTION
This PR fixes the field name mismatch between frontend and API.

**Issue:**
- Dashboard shows 'Total Bugs: 0' even though API returns 1,114 bugs
- Frontend was looking for 'total_bugs' but API returns 'total'
- Charts display data correctly but summary cards don't

**Fix:**
- Updated BugData interface: 'total_bugs' -> 'total'
- Updated summary card to use 'bugData?.total' instead of 'bugData?.total_bugs'

This should make the Total Bugs card display the correct count of 1,114 bugs.