### PR TITLE
Fix: Update Dashboard Overview to use correct API endpoint

### DIFF
--- a/src/components/BugList/BugList.tsx
+++ b/src/components/BugList/BugList.tsx
@@ -64,7 +64,7 @@ interface BugListProps {
 }
 
 const BugList: React.FC<BugListProps> = ({
-  apiGatewayUrl = process.env.NEXT_PUBLIC_API_GATEWAY_URL || 'https://1kvgw5h1qb.execute-api.us-west-2.amazonaws.com/evt-bugtracker/query-bugs'
+  apiGatewayUrl = process.env.NEXT_PUBLIC_API_BASE_URL || 'https://1kvgw5h1qb.execute-api.us-west-2.amazonaws.com/evt-bugtracker/query-bugs'
 }) => {
   const [loading, setLoading] = useState(false);
   const [bugs, setBugs] = useState<BugItem[]>([]);

--- a/src/components/Dashboard/GrafanaDashboard.tsx
+++ b/src/components/Dashboard/GrafanaDashboard.tsx
@@ -54,7 +54,7 @@ interface GrafanaDashboardProps {
 }
 
 const GrafanaDashboard: React.FC<GrafanaDashboardProps> = ({ 
-  apiGatewayUrl = process.env.NEXT_PUBLIC_API_GATEWAY_URL || '/api/dynamodb-bugs'
+  apiGatewayUrl = process.env.NEXT_PUBLIC_API_BASE_URL || 'https://1kvgw5h1qb.execute-api.us-west-2.amazonaws.com/evt-bugtracker/query-bugs'
 }) => {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);


### PR DESCRIPTION
- Change GrafanaDashboard to use NEXT_PUBLIC_API_BASE_URL instead of NEXT_PUBLIC_API_GATEWAY_URL
- Use consistent environment variable across all components
- Fix hardcoded /api/dynamodb-bugs fallback to use correct API endpoint
- This will fix the 'Error Loading Dashboard' issue