### PR TITLE
fix: add cache-busting to prevent stale data in source filtering

### DIFF
--- a/src/components/BugList/BugList.tsx
+++ b/src/components/BugList/BugList.tsx
@@ -181,8 +181,12 @@ const BugList: React.FC<BugListProps> = ({
         }
         
         try {
-          const response = await fetch(`${apiGatewayUrl}?${params.toString()}`, {
-            method: 'GET'
+          const response = await fetch(`${apiGatewayUrl}?${params.toString()}&_t=${Date.now()}`, {
+            method: 'GET',
+            cache: 'no-cache',
+            headers: {
+              'Cache-Control': 'no-cache'
+            }
           });
 
           if (response.ok) {


### PR DESCRIPTION
- Added timestamp parameter and no-cache headers to API calls
- Prevents browser caching from showing old mixed data when filtering
- Should resolve issue where Slack records still appear when filtering by Zendesk