### PR TITLE
fix: remove CORS-problematic headers, keep timestamp cache-busting

### DIFF
--- a/src/components/BugList/BugList.tsx
+++ b/src/components/BugList/BugList.tsx
@@ -182,11 +182,7 @@ const BugList: React.FC<BugListProps> = ({
         
         try {
           const response = await fetch(`${apiGatewayUrl}?${params.toString()}&_t=${Date.now()}`, {
-            method: 'GET',
-            cache: 'no-cache',
-            headers: {
-              'Cache-Control': 'no-cache'
-            }
+            method: 'GET'
           });
 
           if (response.ok) {


### PR DESCRIPTION
- Removed cache and Cache-Control headers causing CORS errors
- Keep timestamp parameter for cache-busting without CORS issues
- Should restore API functionality while preventing cache problems