### PR TITLE
Fix: Prevent Refresh button from bypassing source selection

### DIFF
--- a/src/components/BugList/BugList.tsx
+++ b/src/components/BugList/BugList.tsx
@@ -611,8 +611,15 @@ const BugList: React.FC<BugListProps> = ({
           />
           <Button 
             icon={<FilterOutlined />} 
-            onClick={fetchBugs}
+            onClick={() => {
+              if (selectedSource === 'all') {
+                message.warning('Please select a specific source (Slack, Zendesk, or Shortcut) before refreshing');
+                return;
+              }
+              fetchBugs();
+            }}
             loading={loading}
+            disabled={selectedSource === 'all'}
           >
             Refresh
           </Button>


### PR DESCRIPTION
- Disabled Refresh button when 'All Sources' is selected
- Added warning message if user tries to refresh without selecting specific source
- Ensures consistent behavior: no data fetching without explicit source selection
- Addresses Cursor bot feedback about refresh bypassing intended logic

Resolves issue where Refresh button could fetch mixed data even when source selection was required