### PR TITLE
Fix: Resolve React types dependency conflict for AWS deployment

### DIFF
--- a/amplify.yml
+++ b/amplify.yml
@@ -3,7 +3,7 @@ frontend:
   phases:
     preBuild:
       commands:
-        - npm install
+        - npm install --legacy-peer-deps
         - echo "NEXT_PUBLIC_API_BASE_URL=https://l1izv51p40.execute-api.us-west-2.amazonaws.com/dev" >> .env.local
         - echo "NEXT_PUBLIC_AWS_REGION=us-west-2" >> .env.local
         - echo "NEXT_PUBLIC_ENVIRONMENT=dev" >> .env.local

--- a/package.json
+++ b/package.json
@@ -27,8 +27,8 @@
   },
   "devDependencies": {
     "@types/node": "24.3.0",
-    "@types/react": "^18.2.0",
-    "@types/react-dom": "^18.2.0",
+    "@types/react": "^18.2.25",
+    "@types/react-dom": "^18.2.25",
     "eslint": "9.34.0",
     "eslint-config-next": "15.5.2",
     "typescript": "5.9.2"


### PR DESCRIPTION
- Update @types/react and @types/react-dom to ^18.2.25 to satisfy react-redux@9.2.0 requirements
- Add --legacy-peer-deps flag to npm install in amplify.yml to handle peer dependency conflicts
- Build now succeeds locally and should work in AWS Amplify